### PR TITLE
No longer require table_name to be case-folded

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,24 +3,14 @@ Relational Registry/RegTAP Source Distribution
 
 What's what?
 
-* RegTAP.html -- the document source code.  This is what you
+* RegTAP.tex -- the document source code.  This is what you
   should be editing
 * makeutypes.xslt -- the XSLT to generate utypes from VOResource input; there's
   a wrapper around this in the Makefile (this is included in the standard)
-* RegTAP-fmt.html -- the formatted document.  This will be
-  overwritten, so DO NOT edit this.  To rebuild it, say "make" (provided
-  you have the necessary dependencies, cf. below)
 * Makefile -- document date, version, and status are defined in there.
-  This may also need some adaptation if your build environment is
-  not a Debian squeeze box; common targets are RegistryInterface2.pdf and
-  package.
 * check_examples.py -- runs the embedded examples and complains if
   the TAP server errors out or returns an empty response.  Not needed
   to build the document, see embeeded comments for details.
-* gettables.sh, maketable.sh -- get tables embedded in RegistryInterface2.html
-  from the TAP_SCHEMA.  You need to set TAP_ACCESS_URL for them to work,
-  and you only need to do that if the RR schema has actually changed.
-
-
-See the comment at the top of Makefile for instructions on how to set up
-things so they should work.
+* gettables.sh, maketable.sh -- helper scripts for generated material
+  in the document (make generate).  These assume a server with rr at
+  http://localhost:8080/tap

--- a/RegTAP.tex
+++ b/RegTAP.tex
@@ -2881,6 +2881,13 @@ vocabularies, both accompanying VOResource 1.1.  These translations are:
 
 \section{Changes from Previous Versions}
 
+\subsection{Changes from REC-1.1}
+
+\begin{itemize}
+\item \rtent{table\_name} is no longer case-folded (this is also RegTAP
+1.1 Erratum 1).
+\end{itemize}
+
 \subsection{Changes from REC-1.0}
 
 \begin{itemize}

--- a/RegTAP.tex
+++ b/RegTAP.tex
@@ -657,7 +657,7 @@ Section 5.2 of Registry Interfaces 1.1 additionally requires full RegTAP
 services to register a \xmlel{vg:Registry}-typed record with a (possibly
 auxiliary) TAP capability.  This record is being used by the RofR, and
 it opens up a migration path to a data-based discovery
-pattern\footnote{This would look for schema utypes and apprears
+pattern\footnote{This would look for schema utypes and appears
 desirable to enable multiple instances of a data model within one TAP
 service; it is expected that the recommended discovery pattern
 in RegTAP 1.3 will be updated accordingly.}.
@@ -1402,7 +1402,7 @@ A free-text description of the table's contents.\\
 \baselineskip=9pt\relax table\_name\hfil\break
 \makebox[0pt][l]{\scriptsize\ttfamily xpath:name}&
 \footnotesize string&
-The fully qualified name of the table. This name should include all catalog or schema prefixes needed to distinguish it in a query.\\
+The fully qualified name of the table. This name must include all catalog or schema prefixes needed to distinguish it in a query, and it must contain delimiters where necessary.\\
 
 \baselineskip=9pt\relax table\_index\hfil\break
 \makebox[0pt][l]{\scriptsize\ttfamily }&
@@ -1441,7 +1441,7 @@ maintain an index on at least the \rtent{table\_description}
 column, ideally one suited for queries with \rtent{ivo\_hasword}.
 
 The following columns MUST be lowercased during ingestion:
-\rtent{ivoid}, \rtent{table\_name}, \rtent{table\_type},
+\rtent{ivoid}, \rtent{table\_type},
 \rtent{table\_utype}.
 Clients are advised to query the \rtent{table\_description}
 and \rtent{table\_title}  columns

--- a/RegTAP.tex
+++ b/RegTAP.tex
@@ -1402,7 +1402,7 @@ A free-text description of the table's contents.\\
 \baselineskip=9pt\relax table\_name\hfil\break
 \makebox[0pt][l]{\scriptsize\ttfamily xpath:name}&
 \footnotesize string&
-The fully qualified name of the table. This name must include all catalog or schema prefixes needed to distinguish it in a query, and it must contain delimiters where necessary.\\
+The fully qualified name of the table. As per VODataService, this includes all catalog or schema prefixes needed to distinguish it in a query, and it comes with SQL delimiters where necessary.\\
 
 \baselineskip=9pt\relax table\_index\hfil\break
 \makebox[0pt][l]{\scriptsize\ttfamily }&

--- a/gettables.sh
+++ b/gettables.sh
@@ -5,7 +5,8 @@
 SELECT_CLAUSE="table_name, utype, description"
 QUERY="select $SELECT_CLAUSE from tap_schema.tables 
 	where table_name like 'rr.%' and not table_name like 'rr.stc%'
-	and not table_name='rr.authorities' and not table_name='rr.registries'
+	and not table_name in ('rr.authorities', 'rr.registries',
+	'rr.g_num_stat', 'rr.subject_uat')
 	order by table_name"
 
 


### PR DESCRIPTION
This is putting RegTAP 1.1 Erratum 1 into the document for 1.2.

I'm also sneaking in a bit of README cleanup that won't merit a PR of its own.