### PR TITLE
Draft of specification of stc_ columns

### DIFF
--- a/RegTAP.tex
+++ b/RegTAP.tex
@@ -778,6 +778,19 @@ rr.resource\hfil\break
 \makebox[0pt][l]{\scriptsize\ttfamily xpath:/}&
  The resources (like services, data collections, organizations)
 present in this registry.\\
+rr.stc\_spatial\hfil\break
+\makebox[0pt][l]{\scriptsize\ttfamily xpath:/coverage/spatial}&
+ The spatial coverage of resources.\\
+rr.stc\_spectral\hfil\break
+\makebox[0pt][l]{\scriptsize\ttfamily xpath:/coverage/spectral}&
+ The spectral coverage of resources, given as one or more intervals;
+the total coverage is (a subset of) the union of all intervals given
+for a resource.\\
+rr.stc\_temporal\hfil\break
+\makebox[0pt][l]{\scriptsize\ttfamily xpath:/coverage/temporal}&
+ The temporal coverage of resources, given as one or more intervals;
+the total coverage is (a subset of) the union of all intervals given
+for a resource.\\
 rr.table\_column\hfil\break
 \makebox[0pt][l]{\scriptsize\ttfamily xpath:/(tableset/schema/|)/table/column/}&
  Metadata on columns of a resource's tables.\\
@@ -2238,6 +2251,152 @@ An identifier for the resource or an entity related to the resource in URI form.
 The \rtent{ivoid} column should be an explicit foreign key into
 \rtent{resource}.  It is recommended to maintain an index on
 the \rtent{alt\_identifier} column.
+
+
+\subsection{The stc\_spatial Table}
+\label{table_stc_spatial}
+
+Since VODataService 1.2, registry records can represent their resource's
+spatial coverage using MOCs \citep{2019ivoa.spec.1007F}.  The
+\rtent{stc\_spatial} table is a direct reflection of this metadata:
+
+% GENERATED: maketable.sh rr.stc_spatial
+
+\begin{inlinetable}
+\renewcommand*{\arraystretch}{1.2}
+\small
+\begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
+\sptablerule
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.stc\_spatial} table}}\\
+\sptablerule
+
+\baselineskip=9pt\relax ivoid\hfil\break
+\makebox[0pt][l]{\scriptsize\ttfamily xpath:/identifier}&
+\footnotesize string&
+The parent resource.\\
+
+\baselineskip=9pt\relax coverage\hfil\break
+\makebox[0pt][l]{\scriptsize\ttfamily xpath:.}&
+\footnotesize string\hfil\break+moc&
+A geometry representing the area a resource contains data for; this should be tight at least with a resolution of degrees.\\
+
+\baselineskip=9pt\relax ref\_system\_name\hfil\break
+\makebox[0pt][l]{\scriptsize\ttfamily xpath:@frame}&
+\footnotesize string&
+The reference frame coverage is written in. This is currently reserved and fixed to NULL. Clients should always add a constraint to NULL for this to avoid matching non-celestial resources later.\\
+
+\sptablerule
+\end{tabular}
+\end{inlinetable}
+
+
+% /GENERATED
+
+This specification makes no guarantees on whether or not
+\rtent{coverage} is retrievable (i.e., can be used in ADQL select
+clauses) or in what form it will be returned; this is deferred to a
+future DALI version specifying the moc xtype.  Implementations MUST,
+however, evaluate the ADQL CONTAINS and INTERSECTS predicates with
+coverage as one argument and ADQL CIRCLEs and POLYGONs as the other.
+There are no expectations that the predicates are computed exactly, but
+implementations should strive to limit the number of false positives;
+clients are advised that on services supporting MOC literals, it is
+probably much faster and more exact to use MOC-MOC comparisons to query
+\rtent{coverage}.
+
+\subsection{The stc\_temporal Table}
+\label{table_stc_temporal}
+
+Since VODataService 1.2, registry records can represent their resource's
+temporal coverage as a union of time intervals.  The
+\rtent{stc\_temporal} table is a direct reflection of this metadata:
+
+% GENERATED: maketable.sh rr.stc_temporal
+
+\begin{inlinetable}
+\renewcommand*{\arraystretch}{1.2}
+\small
+\begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
+\sptablerule
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.stc\_temporal} table}}\\
+\sptablerule
+
+\baselineskip=9pt\relax ivoid\hfil\break
+\makebox[0pt][l]{\scriptsize\ttfamily xpath:/identifier}&
+\footnotesize string&
+The parent resource.\\
+
+\baselineskip=9pt\relax time\_start\hfil\break
+\makebox[0pt][l]{\scriptsize\ttfamily xpath:.}&
+\footnotesize real&
+Lower limit of a time interval covered by the resource.\\
+
+\baselineskip=9pt\relax time\_end\hfil\break
+\makebox[0pt][l]{\scriptsize\ttfamily xpath:.}&
+\footnotesize real&
+Upper limit of a time interval covered by the resource.\\
+
+\sptablerule
+\end{tabular}
+\end{inlinetable}
+
+
+% /GENERATED
+
+Clients are advised that the \verb|ivo_interval_overlaps| user defined
+function is available to conveniently compare a user-specified interval
+of interest to \rtent{time\_start} $\cdots$ \rtent{time\_end}.
+
+The \rtent{ivoid} column should be an explicit foreign key into
+\rtent{resource}.
+
+
+\subsection{The stc\_spectral Table}
+\label{table_stc_spectral}
+
+Since VODataService 1.2, registry records can represent their resource's
+spectral coverage as a union of energy intervals.  The
+\rtent{stc\_spectral} table is a direct reflection of this metadata:
+
+% GENERATED: maketable.sh rr.stc_spectral
+
+\begin{inlinetable}
+\renewcommand*{\arraystretch}{1.2}
+\small
+\begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
+\sptablerule
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.stc\_spectral} table}}\\
+\sptablerule
+
+\baselineskip=9pt\relax ivoid\hfil\break
+\makebox[0pt][l]{\scriptsize\ttfamily xpath:/identifier}&
+\footnotesize string&
+The parent resource.\\
+
+\baselineskip=9pt\relax spectral\_start\hfil\break
+\makebox[0pt][l]{\scriptsize\ttfamily xpath:.}&
+\footnotesize real&
+Lower limit of an energy interval covered by the resource (for the solar system barycenter).\\
+
+\baselineskip=9pt\relax spectral\_end\hfil\break
+\makebox[0pt][l]{\scriptsize\ttfamily xpath:.}&
+\footnotesize real&
+Upper limit of an energy interval covered by the resource (for the solar system barycenter).\\
+
+\sptablerule
+\end{tabular}
+\end{inlinetable}
+
+
+% /GENERATED
+
+Clients are advised that the \verb|ivo_interval_overlaps| user defined
+function is available to conveniently compare a user-specified intervals
+of interest to \rtent{spectral\_start} $\cdots$ \rtent{spectral\_end}.
+
+The \rtent{ivoid} column should be an explicit foreign key into
+\rtent{resource}.
+
 
 \section{ADQL User Defined Functions}
 

--- a/gettables.sh
+++ b/gettables.sh
@@ -4,7 +4,7 @@
 
 SELECT_CLAUSE="table_name, utype, description"
 QUERY="select $SELECT_CLAUSE from tap_schema.tables 
-	where table_name like 'rr.%' and not table_name like 'rr.stc%'
+	where table_name like 'rr.%' 
 	and not table_name in ('rr.authorities', 'rr.registries',
 	'rr.g_num_stat', 'rr.subject_uat')
 	order by table_name"


### PR DESCRIPTION
These are tables making available the new metadata from VODataService 1.2.  Adding these is not trivial, as we effectively require in-database MOC support for RegTAP with this.  We *could* put them into a separate data model, but, really, I think MOC in SQL is such a great thing that I'd hope it'll be widely available in the near future anyway.